### PR TITLE
Use query parameter instead of `X-Requested-With` for differentiating HTML or JSON responses

### DIFF
--- a/client/src/minibridge/fetch.ts
+++ b/client/src/minibridge/fetch.ts
@@ -41,13 +41,20 @@ export type DjangoBridgeResponse =
   | ServerErrorResponse
   | NetworkErrorResponse;
 
+/**
+ * The server will respond with JSON if you give it _bridge=1, otherwise with HTML
+ */
+function bridgeUrl(url: string): string {
+  const u = new URL(url, window.location.origin);
+  u.searchParams.set("_bridge", "1");
+  return u.pathname + u.search + u.hash;
+}
+
 export async function djangoGet(url: string): Promise<DjangoBridgeResponse> {
   let response: Response;
 
-  const headers: HeadersInit = { "X-Requested-With": "DjangoBridge" };
-
   try {
-    response = await fetch(url, { headers });
+    response = await fetch(bridgeUrl(url));
   } catch (e) {
     return {
       action: "network-error",
@@ -74,12 +81,9 @@ export async function djangoPost(
 ): Promise<DjangoBridgeResponse> {
   let response: Response;
 
-  const headers: HeadersInit = { "X-Requested-With": "DjangoBridge" };
-
   try {
-    response = await fetch(url, {
+    response = await fetch(bridgeUrl(url), {
       method: "post",
-      headers,
       body: data,
     });
   } catch (e) {

--- a/server/cafe-backend/cafe/bridge/middleware.py
+++ b/server/cafe-backend/cafe/bridge/middleware.py
@@ -11,12 +11,21 @@ from django.templatetags.static import static
 
 from .response import BaseResponse, RedirectResponse
 
+BRIDGE_PARAM = "_bridge"
+
 
 class DjangoBridgeMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
 
     def __call__(self, request):
+        is_bridge_request = BRIDGE_PARAM in request.GET
+
+        # Strip the _bridge param so view code never sees it
+        if is_bridge_request:
+            request.GET = request.GET.copy()
+            del request.GET[BRIDGE_PARAM]
+
         response = self.get_response(request)
 
         if isinstance(response, StreamingHttpResponse):
@@ -25,9 +34,8 @@ class DjangoBridgeMiddleware:
         if response.status_code == 301:
             return response
 
-        # If the request was made by Django Bridge
-        # (using `fetch()`, rather than a regular browser request)
-        if request.META.get("HTTP_X_REQUESTED_WITH") == "DjangoBridge":
+        # If the request was made via the bridge client
+        if is_bridge_request:
             # Convert redirect responses to a JSON response with a `redirect` status
             # This allows the client code to handle the redirect
             if response.status_code == 302:

--- a/server/cafe-backend/cafe/bridge/response.py
+++ b/server/cafe-backend/cafe/bridge/response.py
@@ -5,7 +5,6 @@ import warnings
 from django.conf import settings
 from django.contrib import messages
 from django.http import JsonResponse
-from django.utils.cache import patch_cache_control
 from django.utils.html import conditional_escape
 from django.utils.module_loading import import_string
 
@@ -37,15 +36,6 @@ class BaseResponse(JsonResponse):
         }
         super().__init__(self.data, status=status)
         self["X-DjangoBridge-Action"] = self.action
-
-        # Make sure that Django Bridge responses are never cached by browsers
-        # We need to do this because Django Bridge responses are given on the same URLs that
-        # users would otherwise get HTML responses on if they visited those URLs
-        # directly.
-        # If a Django Bridge response is cached, there's a chance that a user could see the
-        # JSON document in their browser rather than a HTML page.
-        # This behaviour only seems to occur (intermittently) on Firefox.
-        patch_cache_control(self, no_store=True)
 
 
 class Response(BaseResponse):

--- a/server/cafe-backend/cafe/tests/conftest.py
+++ b/server/cafe-backend/cafe/tests/conftest.py
@@ -24,18 +24,24 @@ def client():
     from django.test import Client
     return Client()
 
+class BridgeClient(Client):
+    """Test client that appends ?_bridge=1, causing the bridge middleware to return JSON."""
+
+    def _add_bridge_param(self, path):
+        sep = "&" if "?" in path else "?"
+        return f"{path}{sep}_bridge=1"
+
+    def get(self, path, *args, **kwargs):
+        return super().get(self._add_bridge_param(path), *args, **kwargs)
+
+    def post(self, path, *args, **kwargs):
+        return super().post(self._add_bridge_param(path), *args, **kwargs)
+
+
 @pytest.fixture
 def bridge_client():
-    """
-    Fixture to provide a test client with the X-Requested-With header.
-    This causes the bridge middleware to return JSON
-    """
-    from django.test import Client
-    return Client(
-        headers={
-            "X-Requested-With": "DjangoBridge"
-        }
-    )
+    """Fixture to provide a test client that goes through the bridge middleware."""
+    return BridgeClient()
 
 @pytest.fixture
 def user_with_no_clubs():

--- a/server/cafe-backend/orchard/settings.py
+++ b/server/cafe-backend/orchard/settings.py
@@ -47,7 +47,6 @@ CORS_ALLOW_ALL_ORIGINS = False
 
 CORS_ALLOW_HEADERS = (
     *default_headers,
-    "X-Requested-With"
 )
 
 AUTHENTICATION_BACKENDS = [


### PR DESCRIPTION
This fixes a theoretical bug where Cloudflare may accidentally cache the JSON version of a page and serve it to clients that are requesting the HTML version, or vice-versa. This doesn't happen at the moment because we serve `no-store` headers in our responses. However, Cloudflare (and browsers) don't _have_ to respect these, and if they don't, we could get the wrong version being cached.

Instead we are using a query parameter `_bridge=1`. 

This will break any third party clients that are relying on the `X-Requested-With: DjangoBridge` header. I should check if anyone is actually doing this, but I think since there's a proper API for search, it should be fine? like you're either using the search API or the datasette I think...