### PR TITLE
Set filename length to 80 chars

### DIFF
--- a/server/cafe-backend/cafe/views/rdlevels/download_rdlevel.py
+++ b/server/cafe-backend/cafe/views/rdlevels/download_rdlevel.py
@@ -6,8 +6,7 @@ from django.shortcuts import get_object_or_404
 from cafe.models.rdlevels.rdlevel import RDLevel
 
 # Including the rdzip extension.
-# This number was determined through experimentation on how long filenames RD supports.
-MAXIMUM_FILENAME_LENGTH = 123
+MAXIMUM_FILENAME_LENGTH = 100
 
 def get_filename_for_rdlevel(rdlevel: RDLevel) -> str:
     num_authors = len(rdlevel.authors)

--- a/server/cafe-backend/cafe/views/rdlevels/download_rdlevel.py
+++ b/server/cafe-backend/cafe/views/rdlevels/download_rdlevel.py
@@ -6,7 +6,7 @@ from django.shortcuts import get_object_or_404
 from cafe.models.rdlevels.rdlevel import RDLevel
 
 # Including the rdzip extension.
-MAXIMUM_FILENAME_LENGTH = 100
+MAXIMUM_FILENAME_LENGTH = 80
 
 def get_filename_for_rdlevel(rdlevel: RDLevel) -> str:
     num_authors = len(rdlevel.authors)


### PR DESCRIPTION
Attempt to address #75 

We previously lowered it to 100 but this appears to still be too long for some Windows devices. Lowering it down to 80 may help further. 

80 in roman numerals is LXXX and I couldn't think of any possible cryptic that would incorporate that