### PR TITLE
Fix overflow on long artist lines

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -48,6 +48,9 @@
         "typescript-eslint": "^8.32.0",
         "vite": "^6.4.2",
         "vite-bundle-analyzer": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "../django-bridge/packages/react": {

--- a/client/src/components/LevelCard/LevelCard.tsx
+++ b/client/src/components/LevelCard/LevelCard.tsx
@@ -125,7 +125,7 @@ export function LevelCard({
             )}
           </div>
           <ConjunctionList
-            className="list-none pl-0 flex"
+            className="list-none pl-0 flex flex-wrap"
             items={level.artist_tokens}
             elementRender={(v) => (
               <p className="whitespace-pre text-xs leading-4 text-slate-500 dark:text-slate-400 font-light m-0">

--- a/client/src/components/LevelCard/LevelCard.tsx
+++ b/client/src/components/LevelCard/LevelCard.tsx
@@ -143,7 +143,7 @@ export function LevelCard({
           <div className="flex items-center text-xs leading-[1.125rem] text-slate-500 dark:text-slate-400">
             <FontAwesomeIcon icon={faPen} className="w-4 h-4" />
             <ConjunctionList
-              className="ml-1 p-0 list-none"
+              className="ml-1 p-0 list-none flex-wrap"
               elementRender={(v) =>
                 typeof v === "string" ? (
                   <Words as="span" className="whitespace-pre text-slate-500 dark:text-slate-400 text-xs">

--- a/client/src/views/Level/LevelSearch/LevelSearch.tsx
+++ b/client/src/views/Level/LevelSearch/LevelSearch.tsx
@@ -128,7 +128,7 @@ export const LevelSearch: React.FC<LevelSearchProps> = ({ results }) => {
           </Words>
           {nextPrevButtons}
         </div>
-        <ul className="list-none grid gap-4 [--grid-column-count:3] [--grid-item--min-width:18rem] [--gap-count:calc(var(--grid-column-count)-1)] [--total-gap-width:calc(var(--gap-count)*1rem)] [--grid-item--max-width:calc((100%-var(--total-gap-width))/var(--grid-column-count))] grid-cols-[repeat(auto-fill,minmax(max(var(--grid-item--min-width),var(--grid-item--max-width)),1fr))]">
+        <ul className="list-none grid gap-4 [--grid-column-count:5] [--grid-item--min-width:18rem] [--gap-count:calc(var(--grid-column-count)-1)] [--total-gap-width:calc(var(--gap-count)*1rem)] [--grid-item--max-width:calc((100%-var(--total-gap-width))/var(--grid-column-count))] grid-cols-[repeat(auto-fill,minmax(max(var(--grid-item--min-width),var(--grid-item--max-width)),1fr))]">
           {results.hits.slice(0, LEVELS_PER_PAGE).map((level) => (
             <li key={level.id}>
               <LevelCard

--- a/client/src/views/Level/LevelView/LevelView.tsx
+++ b/client/src/views/Level/LevelView/LevelView.tsx
@@ -109,6 +109,7 @@ export function LevelView({ rdlevel, can_edit, can_delete }: LevelViewProps) {
                 <div className="flex-1 flex flex-col gap-2">
                   <div>
                     <ConjunctionList
+                      className="flex-wrap"
                       items={rdlevel.artist_tokens}
                       elementRender={(v) => (
                         <Words variant="muted" className="text-sm whitespace-pre leading-4">

--- a/client/src/views/Level/LevelView/LevelView.tsx
+++ b/client/src/views/Level/LevelView/LevelView.tsx
@@ -139,10 +139,10 @@ export function LevelView({ rdlevel, can_edit, can_delete }: LevelViewProps) {
                         icon={faPen}
                       />
                       <ConjunctionList
-                        className="gap-1"
+                        className="flex-wrap flex"
                         elementRender={(v) =>
                           typeof v === "string" ? (
-                            <Words className="text-sm">
+                            <Words className="text-sm whitespace-pre">
                               {v}
                             </Words>
                           ) : (
@@ -150,7 +150,7 @@ export function LevelView({ rdlevel, can_edit, can_delete }: LevelViewProps) {
                           )
                         }
                         literalRender={(v) => (
-                          <Words className="text-sm">
+                          <Words className="text-sm whitespace-pre">
                             {v}
                           </Words>
                         )}


### PR DESCRIPTION
close #77 

<img width="752" height="820" alt="image" src="https://github.com/user-attachments/assets/24b80931-2c3a-4556-8c4b-99baa56f3f6b" />'
<img width="1706" height="970" alt="image" src="https://github.com/user-attachments/assets/090ce81e-0f83-470b-a45f-92d109429207" />

Also fixes issue for authors, and makes the maximum allowable columns in level view 5 instead of 3 <sup>I bought a big monitor recently to replace the 13inch portable I've been using and realised how big the cards get