### PR TITLE
Add an instructional landing page for PR environments

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -21,7 +21,7 @@
             The page will now load the frontend from this PR build.
             To deactivate, run:    
         </p>
-        <code>document.cookie = "_pr_client=; max-age=0"</code>
+        <code>document.cookie = "_pr_client=; max-age=0; path=/"</code>
         <p>
             in the same console.
         </p>

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>PR Information Page</title>
+        <link rel="stylesheet" href="https://matcha.mizu.sh/matcha.css">
+    </head>
+    <body>
+        <h1>Rhythm Cafe PR preview: <code data-template>{prSlug}</code></h1>
+        <p>
+            This is a frontend-only build of PR <strong data-template>{prSlug}</strong>.
+            Preview instructions:
+        </p>
+        <ol>
+            <li>Go to <a href="https://rhythm.cafe">rhythm.cafe</a>; open DevTools (<kbd>F12</kbd>)</li>
+            <li>Open <strong>Console</strong> tab and paste this command:</li>
+        </ol>
+        <code data-template>document.cookie = "_pr_client={prSlug}; path=/";</code>
+        <p>
+            The page will now load the frontend from this PR build.
+            To deactivate, run:    
+        </p>
+        <code>document.cookie = "_pr_client=; max-age=0"</code>
+        <p>
+            in the same console.
+        </p>
+        <script>
+// The PR slug is the most nested subdomain (e.g. `pr-123` in `pr-123.orchard-pr.pages.dev`).
+const prSlug = window.location.hostname.split('.')[0];
+// Get all elements containing data-template and replace `{prSlug}` with the actual PR slug.
+document.querySelectorAll('[data-template]').forEach(el => {
+    el.innerHTML = el.innerHTML.replace(/{prSlug}/g, prSlug);
+});
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
The cloudflare pages preview links currently 404. This adds a small index.html that explains that the `_pr_client` cookie should be set to view the preview.