### PR TITLE
Add support for banning users via `is_active` field

### DIFF
--- a/server/cafe-backend/cafe/middleware/api_key.py
+++ b/server/cafe-backend/cafe/middleware/api_key.py
@@ -1,4 +1,3 @@
-from django.contrib.auth.models import AnonymousUser
 from django.http import HttpRequest
 from cafe.models import User
 
@@ -6,12 +5,9 @@ from cafe.models import User
 class ApiKeyAuthenticationMiddleware:
     """
     Middleware that authenticates users via API key in the Authorization header.
-    
-    If an API key is provided in the format "Bearer <key>", this middleware will
-    attempt to authenticate the user with that key and set request.user.
-    
-    If no API key is provided or authentication fails, the request proceeds normally
-    (allowing session-based authentication to work).
+    (The header should be in the format "Bearer <key>.")
+
+    Falls through to session user if no key provided.
     """
     
     def __init__(self, get_response):
@@ -26,13 +22,8 @@ class ApiKeyAuthenticationMiddleware:
             
             # Unsign and validate the token
             user = User.get_user_from_api_key(api_key)
-            if user:
+            if user and user.is_active:
                 request.user = user
-                request.api_key_authenticated = True
-            else:
-                request.api_key_authenticated = False
-        else:
-            request.api_key_authenticated = False
         
         response = self.get_response(request)
         return response

--- a/server/cafe-backend/cafe/models/user.py
+++ b/server/cafe-backend/cafe/models/user.py
@@ -100,6 +100,11 @@ class User(AbstractUser):
             
         except (BadSignature, AttributeError, TypeError):
             return False
+
+    def save(self, *args, **kwargs):
+        if not self.is_active:
+            self.revoke_api_key(False)
+        super().save(*args, **kwargs)
     
     @classmethod
     def get_user_from_api_key(cls, signed_token: str) -> "User | None":
@@ -132,7 +137,7 @@ class User(AbstractUser):
         
         return None
     
-    def revoke_api_key(self) -> None:
+    def revoke_api_key(self, save=True) -> None:
         """
         Revoke the user's API key by incrementing the iteration counter.
         
@@ -140,7 +145,8 @@ class User(AbstractUser):
         track them individually.
         """
         self.api_key_iter += 1
-        self.save()
+        if save:
+            self.save()
 
     def __str__(self):
         return f"{self.display_name} ({self.id})"

--- a/server/cafe-backend/cafe/tests/test_api_keys.py
+++ b/server/cafe-backend/cafe/tests/test_api_keys.py
@@ -364,9 +364,12 @@ def test_banned_user_api_key_rejected_by_middleware(client: Client):
     user = User.objects.create_user(username="testuser")
     api_key = user.generate_api_key()
 
-    user.is_active = False
-    user.save()
+    # user is not active but their API key is still ok because revoke is not called
+    # on a db-level update.
+    User.objects.filter(pk=user.pk).update(is_active=False)
+    user.refresh_from_db()
 
+    # however even a valid API key shouldn't work if user is inactive.
     response = client.get('/accounts/profile/', HTTP_AUTHORIZATION=f'Bearer {api_key}')
     assert response.status_code == 302
     assert '/accounts/login/' in response.url

--- a/server/cafe-backend/cafe/tests/test_api_keys.py
+++ b/server/cafe-backend/cafe/tests/test_api_keys.py
@@ -337,3 +337,57 @@ def test_api_key_with_old_iteration_rejected():
     # Old key should no longer work
     assert not user.check_api_key(old_key)
     assert User.get_user_from_api_key(old_key) is None
+
+
+# --- Ban behaviour ---
+
+@pytest.mark.django_db
+def test_banning_user_revokes_api_key():
+    """Setting is_active=False should increment api_key_iter, invalidating any existing key."""
+    user = User.objects.create_user(username="testuser")
+    api_key = user.generate_api_key()
+    assert user.api_key_iter == 1
+    assert user.check_api_key(api_key)
+
+    user.is_active = False
+    user.save()
+    user.refresh_from_db()
+
+    assert user.api_key_iter == 2
+    assert not user.check_api_key(api_key)
+    assert User.get_user_from_api_key(api_key) is None
+
+
+@pytest.mark.django_db
+def test_banned_user_api_key_rejected_by_middleware(client: Client):
+    """A banned user's API key must be rejected by ApiKeyAuthenticationMiddleware."""
+    user = User.objects.create_user(username="testuser")
+    api_key = user.generate_api_key()
+
+    user.is_active = False
+    user.save()
+
+    response = client.get('/accounts/profile/', HTTP_AUTHORIZATION=f'Bearer {api_key}')
+    assert response.status_code == 302
+    assert '/accounts/login/' in response.url
+
+
+@pytest.mark.django_db
+def test_banned_user_session_rejected(client: Client):
+    """A banned user whose session cookie is still present should be treated as anonymous.
+    
+    Django's ModelBackend.get_user() returns None for inactive users, so the
+    session resolves to AnonymousUser and the view redirects to login.
+    """
+    # use the plain client (not bridge_client) because the bridge middleware converts
+    # 302s into 200 JSON responses which would obscure the assertion.
+
+    user = User.objects.create_user(username="testuser")
+    client.force_login(user)
+
+    user.is_active = False
+    user.save()
+
+    response = client.get('/accounts/profile/')
+    assert response.status_code == 302
+    assert '/accounts/login/' in response.url

--- a/server/cafe-backend/cafe/tests/test_discord_bot_add.py
+++ b/server/cafe-backend/cafe/tests/test_discord_bot_add.py
@@ -590,3 +590,52 @@ def test_step_update_modal_with_overwrite_metadata_sets_flag(
     assert prefill is not None
     assert prefill.overwrite_metadata is True
     mock_prefill.assert_called_once_with(prefill.id, session.id)
+
+
+# ---- Banned user ----
+
+def _pre_ban_discord_user(discord_user_id: str, discord_username: str):
+    """Create a banned user with the given Discord ID."""
+    from cafe.models.rdlevels.tempuser import get_or_create_discord_user
+    user = get_or_create_discord_user(discord_user_id, discord_username)
+    user.is_active = False
+    user.save()
+    return user
+
+
+@pytest.mark.django_db
+def test_add_rejects_banned_user(client_with_discord_key, discord_guild_with_attached_club):
+    client, private_key = client_with_discord_key
+    _pre_ban_discord_user(SAME_USER_AUTHOR["id"], SAME_USER_AUTHOR["global_name"])
+
+    body = make_discord_body(
+        False, discord_guild_with_attached_club.id, ["level.rdzip"],
+        SAME_USER_AUTHOR, SAME_USER_INVOKER,
+    )
+    request = create_discord_request(body, private_key)
+    response = client.post("/discord_interactions/", **request)
+    assert response.status_code == 200
+    assert response.json() == {
+        "data": {"content": "You cannot add levels because your user is inactive.", "flags": 64},
+        "type": 4,
+    }
+    assert not AddSession.objects.filter(id=body["id"]).exists()
+
+
+@pytest.mark.django_db
+def test_add_delegated_rejects_banned_poster(client_with_discord_key, discord_guild_with_attached_club):
+    client, private_key = client_with_discord_key
+    _pre_ban_discord_user(DIFFERENT_AUTHOR["id"], DIFFERENT_AUTHOR["global_name"])
+
+    body = make_discord_body(
+        True, discord_guild_with_attached_club.id, ["level.rdzip"],
+        DIFFERENT_AUTHOR, SAME_USER_INVOKER,
+    )
+    request = create_discord_request(body, private_key)
+    response = client.post("/discord_interactions/", **request)
+    assert response.status_code == 200
+    assert response.json() == {
+        "data": {"content": "You cannot add levels because your user is inactive.", "flags": 64},
+        "type": 4,
+    }
+    assert not AddSession.objects.filter(id=body["id"]).exists()

--- a/server/cafe-backend/cafe/views/discord_bot/handlers/add.py
+++ b/server/cafe-backend/cafe/views/discord_bot/handlers/add.py
@@ -184,7 +184,9 @@ def add_v2(data, check_user_is_poster=True):
             return ephemeral_response("You can only add levels from your own messages.")
         
     user = get_or_create_discord_user(poster_id, message['author'].get('global_name') or message['author']['username'])
-    
+    if not user.is_active:
+        return ephemeral_response("You cannot add levels because your user is inactive.")
+
     # if there are multiple attachments, we need to ask the user which one they want to add, which means we are on phase 1
     # if there is only one attachment, we can skip straight to phase 2, which asks the user if this is a new level or an update to an existing level.
     phase = AddSessionPhase.SELECTING_ATTACHMENT if len(attachments) > 1 else AddSessionPhase.SELECTING_TYPE

--- a/server/cafe-backend/cafe/views/discord_bot/handlers/become_admin.py
+++ b/server/cafe-backend/cafe/views/discord_bot/handlers/become_admin.py
@@ -12,7 +12,7 @@ def becomeadmin(data):
     invoker_id = data['member']['user']['id']
     user = get_or_create_discord_user(invoker_id, data['member']['user'].get('global_name') or data['member']['user']['username'])
     if not user.is_active:
-        return ephemeral_response("Cannot promote the user because the user is inactive.")
+        return ephemeral_response("Cannot promote you because you are inactive.")
     membership = ClubMembership(
         user=user,
         club=club,

--- a/server/cafe-backend/cafe/views/discord_bot/handlers/become_admin.py
+++ b/server/cafe-backend/cafe/views/discord_bot/handlers/become_admin.py
@@ -11,6 +11,8 @@ def becomeadmin(data):
         return not_found_response
     invoker_id = data['member']['user']['id']
     user = get_or_create_discord_user(invoker_id, data['member']['user'].get('global_name') or data['member']['user']['username'])
+    if not user.is_active:
+        return ephemeral_response("Cannot promote the user because the user is inactive.")
     membership = ClubMembership(
         user=user,
         club=club,


### PR DESCRIPTION
I intend to use the inbuilt Django feature `is_active` as a way to ban users. This PR adds `is_active` checking to various bits of the app that don't directly go through Django (e.g. add flow, API calls)