### PR TITLE
add ids for peer review filter radiobuttons

### DIFF
--- a/client/src/views/Level/LevelSearch/LevelsSearchSidebar/PeerReviewStatusSelect.tsx
+++ b/client/src/views/Level/LevelSearch/LevelsSearchSidebar/PeerReviewStatusSelect.tsx
@@ -30,6 +30,7 @@ export function PeerReviewStatusSelect() {
             key={status.value}
             name="peer_review"
             label={status.label}
+            id={"pr-filter-" + status.value}
             checked={currentStatus === status.value}
             onChange={() => {
               // Update local state immediately for responsive UI


### PR DESCRIPTION
this means you can click the label to change the peer review filter instead of having to click the radio button itself

(this is recommended for accessibility anyway)